### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/iloving/vault-plugin-secrets-acme/security/code-scanning/1](https://github.com/iloving/vault-plugin-secrets-acme/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the workflow or job and set it to the lowest necessary privileges. This workflow only checks out code, installs dependencies, and runs tests, none of which require the GITHUB_TOKEN to have write privileges. The best practice is to add `permissions: contents: read` either at the root level (covering all jobs) or directly to the `test` job. Since only one job is present, both approaches are equivalent, but root-level is preferred for clarity and possible future jobs.  
**Edit the top of `.github/workflows/test.yml` to add**:

```yaml
permissions:
  contents: read
```

**just after the `name` block** (before `on:`). No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
